### PR TITLE
Update mod.conf

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,6 @@
 name = void_totem
 description = A totem that prevents you from dying in the void
-depends = mcl_damage, mcl_colors, mcl_worlds, mcl_inventory, mcl_spawn, mcl_totems, mcl_particles
+depends = mcl_damage, mcl_colors, mcl_worlds, mcl_inventory, mcl_spawn, mcl_totems
 optional_depends =
 author = MineClone2 Mods
 title = Void Totem


### PR DESCRIPTION
Remove dependency to mcl_particules since it seems to not be used and a recent change in mineclonia 0.98.0 removed the mod mcl_particules from the game.
So removing the apparently useless dependency make the mod works in mineclonia


